### PR TITLE
Added first version of systemd kzorpd service file

### DIFF
--- a/daemon/kzorpd
+++ b/daemon/kzorpd
@@ -22,7 +22,7 @@ import sys
 sys.dont_write_bytecode = True
 
 import daemon
-from daemon.pidlockfile import PIDLockFile
+from lockfile.pidlockfile import PIDLockFile
 import itertools
 
 import os

--- a/daemon/kzorpd
+++ b/daemon/kzorpd
@@ -22,7 +22,10 @@ import sys
 sys.dont_write_bytecode = True
 
 import daemon
-from lockfile.pidlockfile import PIDLockFile
+try:
+    from daemon.pidlockfile import PIDLockFile
+except ImportError:
+    from lockfile.pidlockfile import PIDLockFile
 import itertools
 
 import os

--- a/rpm/kzorpd.service
+++ b/rpm/kzorpd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Kzorp dynamic hostnames
+
+[Service]
+Type=simple
+PIDFile=/var/run/zorp/kzorpd.pid
+ExecStart=/usr/sbin/kzorpd --user root --group root --no-caps
+ExecStop=/usr/bin/kill $MAINPID
+ExecReload=/usr/bin/kill -s SIGHUP $MAINPID
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
It looks like the location of the latest pidlockfile class is changed, and rhel uses the new location. This exception handling will do the trick.
Also first version of systemd service file is added.

Please review!
